### PR TITLE
fix: keep prefered language private

### DIFF
--- a/Backend/src/Controllers/UsersController.js
+++ b/Backend/src/Controllers/UsersController.js
@@ -162,7 +162,7 @@ export default class UsersController {
             );
 
         privateUser.email = user.email;
-        privateUser.prefered_language = user.prefered_language
+        privateUser.prefered_language = user.prefered_language;
 
         return privateUser;
     }

--- a/Backend/src/Controllers/UsersController.js
+++ b/Backend/src/Controllers/UsersController.js
@@ -162,6 +162,7 @@ export default class UsersController {
             );
 
         privateUser.email = user.email;
+        privateUser.prefered_language = user.prefered_language
 
         return privateUser;
     }

--- a/Backend/src/Utils/getPublicUser.js
+++ b/Backend/src/Utils/getPublicUser.js
@@ -10,7 +10,6 @@ export default async function getPublicUser(user) {
         last_name: user.last_name,
         biography: user.biography,
         profile_picture: profilePicture,
-        prefered_language: user.prefered_language,
     };
 
     return publicUser;


### PR DESCRIPTION
This pull request includes changes to the `UsersController` and `getPublicUser` functions to handle user language preferences more consistently across the application. The most important changes include adding the `prefered_language` attribute to the private user object and removing it from the public user object.

Changes to user language preferences:

* [`Backend/src/Controllers/UsersController.js`](diffhunk://#diff-56f018579659adfeaf94449113cc636c51fe4316620354c4bf5d89439d20323bR165): Added the `prefered_language` attribute to the private user object.
* [`Backend/src/Utils/getPublicUser.js`](diffhunk://#diff-834f4cc9f91598910801757d4a850457dd4b496128b745c392b5ffbdc65e7791L13): Removed the `prefered_language` attribute from the public user object.